### PR TITLE
t1.micro -> t2.micro

### DIFF
--- a/terraform/aws-full/packer-ubuntu-docker-compose.json
+++ b/terraform/aws-full/packer-ubuntu-docker-compose.json
@@ -11,7 +11,7 @@
       "owners": ["099720109477"],
       "most_recent": true
     },
-    "instance_type": "t1.micro",
+    "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "devops21ci",
     "force_deregister": true

--- a/terraform/aws-full/packer-ubuntu-docker-rexray.json
+++ b/terraform/aws-full/packer-ubuntu-docker-rexray.json
@@ -11,7 +11,7 @@
       "owners": ["099720109477"],
       "most_recent": true
     },
-    "instance_type": "t1.micro",
+    "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "devops21",
     "force_deregister": true

--- a/terraform/aws-full/packer-ubuntu-docker.json
+++ b/terraform/aws-full/packer-ubuntu-docker.json
@@ -11,7 +11,7 @@
       "owners": ["099720109477"],
       "most_recent": true
     },
-    "instance_type": "t1.micro",
+    "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "devops21",
     "force_deregister": true

--- a/terraform/aws/packer-ubuntu-docker.json
+++ b/terraform/aws/packer-ubuntu-docker.json
@@ -11,7 +11,7 @@
       "owners": ["099720109477"],
       "most_recent": true
     },
-    "instance_type": "t1.micro",
+    "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "devops21",
     "force_deregister": true

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -17,7 +17,7 @@ variable "swarm_workers" {
   default = 2
 }
 variable "swarm_instance_type" {
-  default = "t1.micro"
+  default = "t2.micro"
 }
 variable "swarm_init" {
   default = false

--- a/terraform/packer-ubuntu-docker.json
+++ b/terraform/packer-ubuntu-docker.json
@@ -11,7 +11,7 @@
       "owners": ["099720109477"],
       "most_recent": true
     },
-    "instance_type": "t1.micro",
+    "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "devops21",
     "force_deregister": true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,7 +17,7 @@ variable "swarm_workers" {
   default = 2
 }
 variable "swarm_instance_type" {
-  default = "t1.micro"
+  default = "t2.micro"
 }
 variable "swarm_init" {
   default = false


### PR DESCRIPTION
Note:
The t1.micro is a previous generation instance and it has been replaced
by the t2.micro, which has a much better performance profile. We
recommend using the t2.micro instance type instead of the t1.micro.

http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/\
concepts_micro_instances.html