### PR TITLE
Fix VirtualBox host mounts on Linux

### DIFF
--- a/scripts/dm-swarm-5.sh
+++ b/scripts/dm-swarm-5.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 for i in {1..5}; do
+    VIRTUALBOX_SHARE_FOLDER="$PWD:$PWD" \
     docker-machine create \
         -d virtualbox \
         swarm-$i

--- a/scripts/dm-swarm.sh
+++ b/scripts/dm-swarm.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 for i in 1 2 3; do
-    docker-machine create -d virtualbox swarm-$i
+    VIRTUALBOX_SHARE_FOLDER="$PWD:$PWD" \
+    docker-machine create \
+        -d virtualbox \
+        swarm-$i
 done
 
 eval $(docker-machine env swarm-1)

--- a/scripts/dm-test-swarm.sh
+++ b/scripts/dm-test-swarm.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 for i in 1 2 3; do
+    VIRTUALBOX_SHARE_FOLDER="$PWD:$PWD" \
     docker-machine create \
         -d virtualbox \
         --virtualbox-memory 512 \


### PR DESCRIPTION
Setting `VIRTUALBOX_SHARE_FOLDER` variable for docker-machine forces it to mount only this repo's directory inside VM instead of all user's home directories (Linux: `/home`, OSX: `/Users` Windows: `C:\Users`), which works fine in OSX and Windows but overlaps with service user `docker` of VM.